### PR TITLE
Remove refmaps

### DIFF
--- a/src/main/resources/baguettelib.mixins.json
+++ b/src/main/resources/baguettelib.mixins.json
@@ -3,7 +3,6 @@
   "minVersion": "0.8",
   "package": "com.leclowndu93150.baguettelib.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "baguettelib.refmap.json",
   "mixins": [
     "InventoryMixin",
     "ItemEntityPickupMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs.